### PR TITLE
feat: make the jwt guard work

### DIFF
--- a/api-gateway/src/common/guard/jwt.guard.ts
+++ b/api-gateway/src/common/guard/jwt.guard.ts
@@ -1,27 +1,27 @@
-import { CodeErrorRpcException, JsonRpcContext } from '../microservice/rpc';
-import { ExecutionContext, HttpStatus, Injectable } from '@nestjs/common';
-import { RPCAuthGuard } from './rpc-auth.guard';
-import { LoggerService } from '../logger/logger.service';
-import { HttpStatusMessage } from '../message/http-status.message';
+import { CodeErrorRpcException, JsonRpcContext } from "../microservice/rpc";
+import { ExecutionContext, HttpStatus, Injectable } from "@nestjs/common";
+import { RPCAuthGuard } from "./rpc-auth.guard";
+import { LoggerService } from "../logger/logger.service";
+import { HttpStatusMessage } from "../message/http-status.message";
 
 @Injectable()
-export class JWTGuard extends RPCAuthGuard('jwt') {
+export class JWTGuard extends RPCAuthGuard("jwt") {
   private unauthorizedError = new CodeErrorRpcException(
     HttpStatusMessage.UNAUTHORIZED,
-    HttpStatus.UNAUTHORIZED,
+    HttpStatus.UNAUTHORIZED
   );
   canActivate(context: ExecutionContext) {
     try {
-      LoggerService.log('#JWTGuard.canActivate', JWTGuard.name);
+      LoggerService.log("#JWTGuard.canActivate", JWTGuard.name);
       const authData = context
         .switchToRpc()
         .getContext<JsonRpcContext>()
-        .getMetadataByKey('Authorization');
+        .getMetadataByKey("Authorization");
       if (!authData) {
         LoggerService.error(
-          '#JWTGuard.canActivate',
+          "#JWTGuard.canActivate",
           this.unauthorizedError.stack,
-          JWTGuard.name,
+          JWTGuard.name
         );
         throw this.unauthorizedError;
       }
@@ -29,5 +29,9 @@ export class JWTGuard extends RPCAuthGuard('jwt') {
     } catch (e) {
       throw this.unauthorizedError;
     }
+  }
+
+  getRequest(context: ExecutionContext) {
+    return context.switchToRpc().getContext().req;
   }
 }


### PR DESCRIPTION
Apologies for the automated prettier run and the changes from it. The only other diff that I had locally was disabling the docker compose external network to use the internal one it creates (easier for me) and changes to the `.env` file for personlization. No other code changes were necessary and this all just worked:tm: